### PR TITLE
Fix HTTPS links + typos in Top Builder pages

### DIFF
--- a/lightning-bounties-recap-of-pleblabs-startup-day-2024-cmdx.md
+++ b/lightning-bounties-recap-of-pleblabs-startup-day-2024-cmdx.md
@@ -147,9 +147,8 @@ We owe immense gratitude to [Car](https://primal.net/p/npub1f4www6qjx43mckpkjld4
 
 The connections made, knowledge gained, and support received have been invaluable. We're honored to be part of this vibrant ecosystem and look forward to contributing to its growth.
 
-_**P.S. If you've made it this far and have a bug to squash or a feature to add to your project, you know what to do - head over to**_ [**app.lightningbounties.com**](http://app.lightningbounties.com/)_**, and let's build something amazing together!**_
+_**P.S. If you've made it this far and have a bug to squash or a feature to add to your project, you know what to do - head over to**_ [**app.lightningbounties.com**](https://app.lightningbounties.com/)_**, and let's build something amazing together!**_
 
 
 
 <div align="center"><figure><img src=".gitbook/assets/lb_initals_typography_rectangle_vaporwave_nobg.png" alt=""><figcaption></figcaption></figure> <figure><img src=".gitbook/assets/qr_code_next_lightningbounties.png" alt="" width="563"><figcaption><p><a href="https://app.lightningbounties.com/">Scan The QR Code to Get Started!</a></p></figcaption></figure></div>
-

--- a/mike-abramo/lightning-bounties-recap-of-pleblabs-startup-day-2024-cmdx.md
+++ b/mike-abramo/lightning-bounties-recap-of-pleblabs-startup-day-2024-cmdx.md
@@ -147,9 +147,8 @@ We owe immense gratitude to [Car](https://primal.net/p/npub1f4www6qjx43mckpkjld4
 
 The connections made, knowledge gained, and support received have been invaluable. We're honored to be part of this vibrant ecosystem and look forward to contributing to its growth.
 
-_**P.S. If you've made it this far and have a bug to squash or a feature to add to your project, you know what to do - head over to**_ [**app.lightningbounties.com**](http://app.lightningbounties.com/)_**, and let's build something amazing together!**_
+_**P.S. If you've made it this far and have a bug to squash or a feature to add to your project, you know what to do - head over to**_ [**app.lightningbounties.com**](https://app.lightningbounties.com/)_**, and let's build something amazing together!**_
 
 
 
 <div align="center"><figure><img src="../.gitbook/assets/lb_initals_typography_rectangle_vaporwave_nobg.png" alt=""><figcaption></figcaption></figure> <figure><img src="../.gitbook/assets/qr_code_next_lightningbounties.png" alt="" width="563"><figcaption><p><a href="https://app.lightningbounties.com/">Scan The QR Code to Get Started!</a></p></figcaption></figure></div>
-

--- a/top-builder-2025/top-builder-x-lightning-bounties/README.md
+++ b/top-builder-2025/top-builder-x-lightning-bounties/README.md
@@ -7,16 +7,16 @@ coverY: 0
 
 ## Welcome to Lightning Bounties x Top Builder Page
 
-Thank you for checking out our blog! We document our progress in the PlebLabs Top Builder competition, provide insights into what Lightning Bounties is all about, and share updates on what we and other top builder teams are working with each  week.
+Thank you for checking out our blog! We document our progress in the PlebLabs Top Builder competition, provide insights into what Lightning Bounties is all about, and share updates on what we and other top builder teams are working with each week.
 
 We're Lightning Bounties, dedicating ourselves to Bitcoin Bug Bounties on GitHub!
 
 ## Our Goals For Top Builder&#x20;
 
-At Lightning Bounties, our main goal through the Top Builder competition is to collaborate, build, and learn with participating teams and mentors. You can join us with building Lightning Bounties and earn sats in the process. Need help fixing a pesky bug or want to add a cool feature on your Top Builder projct?&#x20;
+At Lightning Bounties, our main goal through the Top Builder competition is to collaborate, build, and learn with participating teams and mentors. You can join us in building Lightning Bounties and earn sats in the process. Need help fixing a pesky bug or want to add a cool feature on your Top Builder project?&#x20;
 
 {% hint style="info" %}
-Visit our bounty platform at [app.lightningbounties.com](http://app.lightningbounties.com) New bounties posted daily!
+Visit our bounty platform at [app.lightningbounties.com](https://app.lightningbounties.com). New bounties posted daily!
 {% endhint %}
 
 ## About Lightning Bounties
@@ -63,7 +63,7 @@ Stay informed about our progress and updates during the Top Builder competition 
 <table data-card-size="large" data-column-title-hidden data-view="cards" data-full-width="false"><thead><tr><th></th><th></th><th data-hidden data-card-cover data-type="files"></th><th data-hidden data-card-target data-type="content-ref"></th></tr></thead><tbody><tr><td><a href="https://lb-bizdev.notion.site/topbuilder-season-2?v=176e1fe7ce6b8168b785000c4c58ed88"><strong>Business Development Task Tracker</strong></a></td><td>Keep an eye on our business development plans and achievements. This tracker outlines our roadmap and the tasks we focus on during the Top Builder competition.  </td><td><a href="../../.gitbook/assets/notion_bizdev_ss (2).JPG">notion_bizdev_ss (2).JPG</a></td><td><a href="https://lb-bizdev.notion.site/topbuilder-season-2?v=176e1fe7ce6b8168b785000c4c58ed88">https://lb-bizdev.notion.site/topbuilder-season-2?v=176e1fe7ce6b8168b785000c4c58ed88</a></td></tr><tr><td><a href="https://github.com/orgs/Lightning-Bounties/projects/2/views/1"><strong>Development Task Tracker &#x26; Roadmap</strong> </a></td><td>Follow along with our development efforts. This tracker highlights our ongoing projects, key milestones, and progress we've made during the Top Builder competition.</td><td><a href="../../.gitbook/assets/github_tb_issue_ss.JPG">github_tb_issue_ss.JPG</a></td><td><a href="https://github.com/orgs/Lightning-Bounties/projects/2">https://github.com/orgs/Lightning-Bounties/projects/2</a></td></tr></tbody></table>
 
 {% hint style="info" %}
-Did you notice a typo a bug yet? Email me at[ mike@lightningbounties.com](mailto:mike@lightningbounties.com), and I'll send you 1000 sats for pointing out any documentation errors.
+Did you notice a typo or a bug yet? Email me at [mike@lightningbounties.com](mailto:mike@lightningbounties.com), and I'll send you 1000 sats for pointing out any documentation errors.
 {% endhint %}
 
 ## Lightning Bounties Team


### PR DESCRIPTION
Context: bounty issue Lightning-Bounties/our-blog#4 (docs/blog improvements).

Changes
- Replace a few `http://app.lightningbounties.com` links with `https://app.lightningbounties.com` in blog pages.
- Fix minor typos/grammar in the Top Builder x Lightning Bounties README (spacing, wording).

Date: 2026-02-11

Max (SATMAX Agent)}