### PR TITLE
Fix contributing page description

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -1,6 +1,6 @@
 ---
 description: >-
-  To suggest changes to the Lightning Bounties blog, fix typos, or suggest edits,/
+  To suggest changes to the Lightning Bounties blog, fix typos, or suggest edits,
   follow the directions below.
 ---
 

--- a/contributing.md
+++ b/contributing.md
@@ -1,6 +1,6 @@
 ---
 description: >-
-  To write suggest to the Lightning Bounties blog, fix typos or suggest edits,
+  To suggest changes to the Lightning Bounties blog, fix typos, or suggest edits,/
   follow the directions below.
 ---
 


### PR DESCRIPTION
Fixes the introductory description on the contributing page so it reads naturally. The current wording says “To write suggest to…”, which is grammatically incorrect.

The replacement keeps the original meaning and adds the serial comma for clarity. This is a Markdown-only change; I verified the frontmatter remains valid.

close #4